### PR TITLE
Fix a TypeError raised for pip version strings that contain 0s.

### DIFF
--- a/src/dws/__init__.py
+++ b/src/dws/__init__.py
@@ -2067,7 +2067,7 @@ class PipInstallStep(InstallStep):
         pip = find_pip(context)
         site_packages = None
         pip_version = subprocess.check_output([pip, '-V'])
-        look = re.match(r'pip [1-9\.]+ from (\S+)', pip_version)
+        look = re.match(r'pip [0-9\.]+ from (\S+)', pip_version)
         if look:
             site_packages = look.group(1)
         admin = False


### PR DESCRIPTION
Running `dws build` generates the following exception trace:

```
[... lots of snipped output ...]
######## Whoosh:pipinstall...
Traceback (most recent call last):
  File "bin/dws", line 5897, in <module>
    sys.exit(main(sys.argv))
  File "bin/dws", line 5875, in main
    options.func(**func_args)
  File "bin/dws", line 4984, in pub_build
    validate_controls(dgen, INDEX, graph=graph)
  File "bin/dws", line 4571, in validate_controls
    vertex.run(CONTEXT)
  File "bin/dws", line 2074, in run
    if os.stat(site_packages).st_uid != os.getuid():
TypeError: coercing to Unicode: need string or buffer, NoneType found
```

Re-running `dws build` doesn't solve the problem. It gets through several steps before encountering this error.

This is a regex issue with the version string not allowing 0s.